### PR TITLE
Fix: grouping common before transform

### DIFF
--- a/spec/generator__lib_spec.cr
+++ b/spec/generator__lib_spec.cr
@@ -22,7 +22,7 @@ describe "LibGenerator::Generator::Lib" do
       li.ast.should eq(Crystal::Expressions.new(ast_nodes(sources.sort)))
     end
 
-    it "transforms a lib to nothing and returns a Crystal::Expression" do
+    it "transforms a lib to an empty Crystal::Expression" do
       nodes = [ast_node("fun foo")]
       library = LibGenerator::Library.new("LibFoo", "-lfoo", includes: ["bar.yml"])
       li = LibGenerator::Generator::Lib.new(library, LibGenerator::Definition.new)
@@ -31,6 +31,7 @@ describe "LibGenerator::Generator::Lib" do
       ast = li.transform(LibGenerator::RemoveTransformer.new(nodes))
 
       ast.should be_a(Crystal::Expressions)
+      ast.expressions.empty?.should be_true
     end
   end
 

--- a/spec/generator__lib_spec.cr
+++ b/spec/generator__lib_spec.cr
@@ -8,6 +8,32 @@ describe "LibGenerator::Generator::Lib" do
     end
   end
 
+  describe "transform" do
+    it "transforms a lib" do
+      sources = ["fun foo", "fun bar"]
+      library = LibGenerator::Library.new("LibFoo", "-lfoo", includes: ["bar.yml"])
+      transformers = [] of Crystal::Transformer
+      transformers << LibGenerator::SortTransformer.new
+      li = LibGenerator::Generator::Lib.new(library, LibGenerator::Definition.new, transformers)
+      li.ast = Crystal::Expressions.new(ast_nodes(sources))
+
+      li.transform
+
+      li.ast.should eq(Crystal::Expressions.new(ast_nodes(sources.sort)))
+    end
+
+    it "transforms a lib to nothing and returns a Crystal::Expression" do
+      nodes = [ast_node("fun foo")]
+      library = LibGenerator::Library.new("LibFoo", "-lfoo", includes: ["bar.yml"])
+      li = LibGenerator::Generator::Lib.new(library, LibGenerator::Definition.new)
+      li.ast = Crystal::Expressions.new(nodes)
+
+      ast = li.transform(LibGenerator::RemoveTransformer.new(nodes))
+
+      ast.should be_a(Crystal::Expressions)
+    end
+  end
+
   describe "generate_attributes" do
     it "generates Crystal attributes" do
       library = LibGenerator::Library.new("LibFoo", "-lfoo", includes: ["bar.yml"])

--- a/spec/generator_spec.cr
+++ b/spec/generator_spec.cr
@@ -86,6 +86,40 @@ describe "LibGenerator::Generator" do
       li.ast.should eq(Crystal::Expressions.new(ast_nodes(["fun common", "fun foo", "fun bar"])))
       li.requires.should eq([1, 3].map { |i| "./#{i}" })
     end
+
+    it "groups common nodes then apply cosmetic transformers" do
+      sources = [
+        "fun foo\nfun bar",
+        "fun foo\nfun foobar",
+        "fun bar",
+        "fun barfoo",
+      ]
+
+      library = LibGenerator::Library.new("LibFoo", "-lfoo", includes: ["bar.yml"])
+      definitions = sources.size.times.map(&.to_s).to_a.zip(sources.map { LibGenerator::Definition.new }).to_h
+      common_filename = "lib_foo.cr"
+      definitions[common_filename] = LibGenerator::Definition.new
+
+      transformers = [
+        LibGenerator::SortTransformer.new,
+        LibGenerator::RenameTransformer.new({
+          "*" => [{pattern: /foo/, replacement: "foofoo"}],
+        }),
+      ]
+      generator = LibGenerator::Generator.new(library, definitions, transformers)
+
+      generator.libs.each_with_index do |(_, li), i|
+        li.ast = ast_exprs(sources[i]) if i < sources.size
+      end
+
+      generator.libs[common_filename].ast = Crystal::Expressions.new([ast_node("fun common")])
+
+      generator.group_common_nodes
+
+      li = generator.libs[generator.common_filename]
+
+      li.ast.should eq(ast_exprs(["fun bar", "fun common", "fun foo"]))
+    end
   end
 
   describe "generate" do

--- a/spec/generator_spec.cr
+++ b/spec/generator_spec.cr
@@ -34,7 +34,7 @@ describe "LibGenerator::Generator" do
   end
 
   describe "group_common_nodes" do
-    it "groups common nodes in a lib and generates requires" do
+    it "groups common nodes in a lib and generates requires for non-empty libs" do
       sources = [
         "fun foo\nfun bar",
         "fun foo\nfun foobar",
@@ -55,10 +55,10 @@ describe "LibGenerator::Generator" do
       li = generator.libs[generator.common_filename]
 
       li.ast.should eq(Crystal::Expressions.new(ast_nodes(["fun foo", "fun bar"])))
-      li.requires.should eq(definitions.keys.map { |fn| "./#{fn}" })
+      li.requires.should eq([1, 3].map { |fn| "./#{fn}" })
     end
 
-    it "groups common nodes in an existing lib and generates requires" do
+    it "groups common nodes in an existing lib and generates requires for non-empty libs" do
       sources = [
         "fun foo\nfun bar",
         "fun foo\nfun foobar",
@@ -84,7 +84,7 @@ describe "LibGenerator::Generator" do
       li = generator.libs[generator.common_filename]
 
       li.ast.should eq(Crystal::Expressions.new(ast_nodes(["fun common", "fun foo", "fun bar"])))
-      li.requires.should eq(sources.size.times.to_a.map { |i| "./#{i}" })
+      li.requires.should eq([1, 3].map { |i| "./#{i}" })
     end
   end
 end

--- a/spec/generator_spec.cr
+++ b/spec/generator_spec.cr
@@ -26,7 +26,7 @@ describe "LibGenerator::Generator" do
       generator = LibGenerator::Generator.new(library, definitions, [] of Crystal::Transformer)
 
       generator.libs.each_with_index do |(_, li), i|
-        li.ast = Crystal::Parser.parse("lib L\n#{sources[i]}\nend")
+        li.ast = ast_exprs(sources[i])
       end
 
       generator.extract_common_nodes.should eq(ast_nodes(["fun foo", "fun bar"]))
@@ -47,7 +47,7 @@ describe "LibGenerator::Generator" do
       generator = LibGenerator::Generator.new(library, definitions, [] of Crystal::Transformer)
 
       generator.libs.each_with_index do |(_, li), i|
-        li.ast = Crystal::Parser.parse("lib L\n#{sources[i]}\nend")
+        li.ast = ast_exprs(sources[i])
       end
 
       generator.group_common_nodes
@@ -74,7 +74,7 @@ describe "LibGenerator::Generator" do
       generator = LibGenerator::Generator.new(library, definitions, [] of Crystal::Transformer)
 
       generator.libs.each_with_index do |(_, li), i|
-        li.ast = Crystal::Parser.parse("lib L\n#{sources[i]}\nend") if i < sources.size
+        li.ast = ast_exprs(sources[i]) if i < sources.size
       end
 
       generator.libs[common_filename].ast = Crystal::Expressions.new([ast_node("fun common")])

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,6 +6,13 @@ def ast_node(source : String) : Crystal::ASTNode
   Crystal::Parser.parse("lib L\n#{source}\nend").as(Crystal::LibDef).body
 end
 
-def ast_nodes(sources : Array(String)) : Array(Crystal::ASTNode)
-  Crystal::Parser.parse("lib L\n#{sources.join("\n")}\nend").as(Crystal::LibDef).body.as(Crystal::Expressions).expressions
+def ast_exprs(sources : (Array(String) | String)) : Crystal::Expressions
+  sources = sources.join("\n") if sources.is_a?(Array(String))
+  body = Crystal::Parser.parse("lib L\n#{sources}\nend").as(Crystal::LibDef).body
+  body = Crystal::Expressions.new([body]) unless body.as?(Crystal::Expressions)
+  body.as(Crystal::Expressions)
+end
+
+def ast_nodes(sources : (Array(String) | String)) : Array(Crystal::ASTNode)
+  ast_exprs(sources).expressions
 end

--- a/src/lib_generator/generator.cr
+++ b/src/lib_generator/generator.cr
@@ -87,8 +87,8 @@ class LibGenerator::Generator
       )
     end
 
-    common_def.transformers.replace(@transformers)
-    common_def.requires.concat(libs.keys.map { |fn| File.join(".", fn) if fn != @common_filename }.compact)
+    requires = libs.select { |_, v| !v.ast.as(Crystal::Expressions).expressions.empty? }.keys
+    common_def.requires.concat(requires.map { |fn| File.join(".", fn) if fn != @common_filename }.compact)
 
     self
   end

--- a/src/lib_generator/generator/lib.cr
+++ b/src/lib_generator/generator/lib.cr
@@ -14,15 +14,19 @@ class LibGenerator::Generator
     end
 
     def transform
-      ast = @ast
       @transformers.each do |tr|
-        ast = ast.not_nil!.transform(tr)
-        unless ast.is_a?(Crystal::Expressions)
-          ast = Crystal::Expressions.new([ast])
-        end
+        transform(tr)
+      end
+      self
+    end
+
+    def transform(transformer : Crystal::Transformer)
+      ast = @ast.not_nil!
+      ast = ast.transform(transformer)
+      unless ast.is_a?(Crystal::Expressions)
+        ast = Crystal::Expressions.new([ast])
       end
       @ast = ast
-      self
     end
 
     def generate : String?

--- a/src/lib_generator/generator/lib.cr
+++ b/src/lib_generator/generator/lib.cr
@@ -26,6 +26,7 @@ class LibGenerator::Generator
       unless ast.is_a?(Crystal::Expressions)
         ast = Crystal::Expressions.new([ast])
       end
+      ast.expressions.select! { |n| !n.is_a?(Crystal::Nop) }
       @ast = ast
     end
 
@@ -60,7 +61,7 @@ class LibGenerator::Generator
 
     def generate_lib : Crystal::LibDef?
       ast = @ast
-      unless ast.as?(Crystal::Expressions).not_nil!.expressions.empty?
+      unless ast.as(Crystal::Expressions).expressions.empty?
         Crystal::LibDef.new(@library.name, ast).tap do |ln|
           ln.doc = @definition.description
         end

--- a/src/lib_generator/transformers/cosmetic.cr
+++ b/src/lib_generator/transformers/cosmetic.cr
@@ -1,0 +1,4 @@
+# englobing class for transformers that does not perform semantic modifications
+# (re-ordering nodes, formating, etc ...)
+class LibGenerator::CosmeticTransformer < Crystal::Transformer
+end

--- a/src/lib_generator/transformers/sort.cr
+++ b/src/lib_generator/transformers/sort.cr
@@ -1,6 +1,6 @@
 require "compiler/crystal/syntax"
 
-class LibGenerator::SortTransformer < Crystal::Transformer
+class LibGenerator::SortTransformer < LibGenerator::CosmeticTransformer
   def transform(node : Crystal::Expressions)
     node.expressions.sort_by!(&.to_s)
     super


### PR DESCRIPTION
In some cases it can be problematic to group the common nodes before applying the transformations (i.e. when using a RenameTransformer, some duplicates may be created in the output files)