### PR TITLE
Disable Travis CI builds for LLVM 3.9 & 5 on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,7 @@ matrix:
     env: LLVM_VERSION=6.0
   - os: osx
     osx_image: xcode8.3
-    env: LLVM_VERSION=3.9
-  - os: osx
-    osx_image: xcode8.3
     env: LLVM_VERSION=4
-  - os: osx
-    osx_image: xcode8.3
-    env: LLVM_VERSION=5
   - os: osx
     osx_image: xcode8.3
     env: LLVM_VERSION=6


### PR DESCRIPTION
Disable Travis CI builds for LLVM 3.9 & 5 on macOS as the brew formula is not available anymore (see #32)